### PR TITLE
unsafe watermark via InvokeDynamic

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -81,6 +81,7 @@ Shrinker:
 Watermark:
   Enabled: true
   META-INF: false
+  UnsafeInvokeDynamic: false # you MUST pass -noverify.
   Messages:
     - "\n<\\ StarLock: New Modern Protection."
     - " || Web: github.com/DevPaimonSoft/StarLock"

--- a/src/main/java/starlock/obf/obfuscator/transformers/WaterMarkTransformer.java
+++ b/src/main/java/starlock/obf/obfuscator/transformers/WaterMarkTransformer.java
@@ -3,6 +3,7 @@ package starlock.obf.obfuscator.transformers;
 import starlock.obf.obfuscator.Obfuscator;
 import starlock.obf.obfuscator.Transformer;
 import starlock.obf.obfuscator.transformers.impl.watermark.ConsoleTransformer;
+import starlock.obf.obfuscator.transformers.impl.watermark.InvokeDynamicWatermarkTransformer;
 import starlock.obf.obfuscator.transformers.impl.watermark.MetaInfTransformer;
 import starlock.obf.obfuscator.transformers.impl.watermark.WClassTransformer;
 
@@ -11,6 +12,9 @@ public class WaterMarkTransformer extends Transformer {
     public void transform(Obfuscator obfuscator) {
         if(getConfig().getBoolean("Watermark.META-INF")){
             new MetaInfTransformer().obfuscate(obfuscator);
+        }
+        if (getConfig().getBoolean("Watermark.UnsafeInvokeDynamic")) {
+            new InvokeDynamicWatermarkTransformer().obfuscate(obfuscator);
         }
         //if(getConfig().getBoolean("Watermark.META-INF")){
         //    new MetaInfTransformer().obfuscate(obfuscator);

--- a/src/main/java/starlock/obf/obfuscator/transformers/impl/watermark/InvokeDynamicWatermarkTransformer.java
+++ b/src/main/java/starlock/obf/obfuscator/transformers/impl/watermark/InvokeDynamicWatermarkTransformer.java
@@ -1,0 +1,33 @@
+package starlock.obf.obfuscator.transformers.impl.watermark;
+
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+import starlock.obf.obfuscator.Obfuscator;
+import starlock.obf.obfuscator.transformers.WaterMarkTransformer;
+
+/*
+    @author lustman, 2025.
+    заодно ломает дизассемблер в recaf'е.
+*/
+public class InvokeDynamicWatermarkTransformer extends WaterMarkTransformer {
+    public void obfuscate(Obfuscator obfuscator) {
+        obfuscator.getClasses().forEach(classNode -> {
+            classNode.methods.stream()
+                    .filter(methodNode -> methodNode.name.equals("<init>"))
+                    .forEach(methodNode -> {
+                        InsnList insnList = new InsnList();
+                        var l = new LabelNode();
+                        insnList.add(new InsnNode(ACONST_NULL));
+                        insnList.add(new JumpInsnNode(IFEQ, l));
+                        insnList.add(new InvokeDynamicInsnNode("get da starl0ck", "()V", new Handle(Opcodes.H_INVOKESTATIC, "", "yap", "()V;", false)));
+                        insnList.add(new InvokeDynamicInsnNode("lox", "()B", new Handle(Opcodes.H_INVOKESTATIC, "java/lang/0", "", "()L;", false)));
+                        insnList.add(new InsnNode(Opcodes.POP));
+                        insnList.add(l);
+                        AbstractInsnNode first = methodNode.instructions.get(0);
+                        methodNode.instructions.insertBefore(first, insnList);
+                    });
+
+        });
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,6 +81,7 @@ Shrinker:
 Watermark:
   Enabled: true
   META-INF: false
+  UnsafeInvokeDynamic: false # you MUST pass -noverify.
   Messages:
     - "\n<\\ StarLock: New Modern Protection."
     - " || Web: github.com/DevPaimonSoft/StarLock"


### PR DESCRIPTION
нестабильно, с некоторыми трансформерами несовместимо, зато в декомпиляторе смотрится красиво.😁
ну и файл на выходе без -noverify жить не может.